### PR TITLE
Actionsの実行時に出る警告を修正

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -16,7 +16,7 @@ jobs:
         sed 's/refs\/tags\///g' ./versionTUIC_.txt > ./versionTUIC.txt
         cat ./versionTUIC.txt
     - name: shareFile
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: versionTUIC
         path: versionTUIC.txt
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [set-version]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: loadVersion
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: versionTUIC
     - name: Archive
@@ -36,7 +36,7 @@ jobs:
         mv manifest_firefox.json manifest.json
         zip -r Twitter_UI_Customizer_Firefox.xpi ./ -x "*.git*"
     - name: Publish
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: Twitter_UI_Customizer_Firefox
         path: Twitter_UI_Customizer_Firefox.xpi
@@ -46,9 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [set-version]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: loadVersion
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: versionTUIC
     - name: Archive
@@ -57,7 +57,7 @@ jobs:
         mv manifest_chrome.json manifest.json
         zip -r Twitter_UI_Customizer_Chromium.zip ./ -x "*.git*"
     - name: Publish
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: Twitter_UI_Customizer_Chromium
         path: Twitter_UI_Customizer_Chromium.zip
@@ -77,15 +77,15 @@ jobs:
         draft: false
         prerelease: false
     - name: loadVersion
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: versionTUIC
-    - name: loadf
-      uses: actions/download-artifact@v2
+    - name: loadFile
+      uses: actions/download-artifact@v3
       with:
         name: Twitter_UI_Customizer_Firefox
-    - name: loadf
-      uses: actions/download-artifact@v2
+    - name: loadFile
+      uses: actions/download-artifact@v3
       with:
         name: Twitter_UI_Customizer_Chromium
     - name: Upload Release Asset

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -88,20 +88,11 @@ jobs:
       with:
         name: Twitter_UI_Customizer_Chromium
     - name: Upload Release Asset
-      id: upload-release-asset-f
+      id: upload-release-asset
       uses: softprops/action-gh-release@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        files: Twitter_UI_Customizer_Firefox.xpi
-    - name: Upload Release Asset
-      id: upload-release-asset-c
-      uses: softprops/action-gh-release@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        files: Twitter_UI_Customizer_Chromium.zip
-    - name: Upload Release Asset
-      id: upload-release-version
-      uses: softprops/action-gh-release@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        files: versionTUIC.txt
+        files: |
+          Twitter_UI_Customizer_Firefox.xpi
+          Twitter_UI_Customizer_Chromium.zip
+          versionTUIC.txt

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -11,9 +11,7 @@ jobs:
     steps:
     - name: saveFile
       run: |
-        echo ${{ github.ref }} > versionTUIC_.txt
-        cat ./versionTUIC_.txt
-        sed 's/refs\/tags\///g' ./versionTUIC_.txt > ./versionTUIC.txt
+        echo ${{ github.ref_name }} > versionTUIC.txt
         cat ./versionTUIC.txt
     - name: shareFile
       uses: actions/upload-artifact@v3

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -68,12 +68,11 @@ jobs:
     steps:
     - name: Create Release
       id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v1
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Twitter UI Customizer ${{ github.ref }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag_name: ${{ github.ref_name }}
+        name: Twitter UI Customizer ${{ github.ref_name }}
         draft: false
         prerelease: false
     - name: loadVersion
@@ -89,32 +88,20 @@ jobs:
       with:
         name: Twitter_UI_Customizer_Chromium
     - name: Upload Release Asset
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      id: upload-release-asset-f
+      uses: softprops/action-gh-release@v1
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: Twitter_UI_Customizer_Firefox.xpi
-        asset_name: Twitter_UI_Customizer_Firefox.xpi
-        asset_content_type: application/zip
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: Twitter_UI_Customizer_Firefox.xpi
     - name: Upload Release Asset
-      id: upload-release-asset2
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      id: upload-release-asset-c
+      uses: softprops/action-gh-release@v1
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: Twitter_UI_Customizer_Chromium.zip
-        asset_name: Twitter_UI_Customizer_Chromium.zip
-        asset_content_type: application/zip
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: Twitter_UI_Customizer_Chromium.zip
     - name: Upload Release Asset
       id: upload-release-version
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v1
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: versionTUIC.txt
-        asset_name: versionTUIC.txt
-        asset_content_type: text/plain
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: versionTUIC.txt


### PR DESCRIPTION
- actionのバージョンを更新(Node.js 12がサポート対象外になったため)
- メンテナンスされなくなったaction (actions/create-releaseとactions/upload-release-asset) を
推奨されている softprops/action-gh-releaseに置き換え(使用できなくなるset-outputを使っていたため)
- github.ref_nameを使えば不要な処理を削除