### PR TITLE
カスタムアイコンのプレビューに枠が表示されるバグの修正

### DIFF
--- a/scr/applyCSS.js
+++ b/scr/applyCSS.js
@@ -490,6 +490,7 @@ height:8px
 display:none !important;
 }
 .TUICUploadedImg{
+    display:inline-block;
     width:64px;
     height:64px;
 }

--- a/scr/option.js
+++ b/scr/option.js
@@ -585,6 +585,6 @@ ${TUICVisibleButtons}
         return `<h3 class="r-jwli3a r-1tl8opc r-qvutc0 r-bcqeeo css-901oao TUIC_setting_title">${TUICLibrary.getI18n(title)}</h3><br>
         <input type="file" accept="image/*" class="TUIC_setting_text TUICSelectImg" TUICImgID="${id}" />
         <p class="TUIC_setting_text">${TUICLibrary.getI18n("twitterIcon-nowIcon")}</p>
-        <img id="TUICIcon_${id}" class="TUICUploadedImg">`
+        <span id="TUICIcon_${id}" class="TUICUploadedImg">`
     }
 }


### PR DESCRIPTION
画像を設定しても消えなくて邪魔なので表示されないようにしました
(Firefoxだと左上の四角はないみたい)
![image](https://github.com/kaonasi-biwa/Twitter-UI-Customizer/assets/87810571/16e651f2-d89f-4b18-b7b5-e815ad8d677d)

アイコンを丸くすると違和感が増大する
![image](https://github.com/kaonasi-biwa/Twitter-UI-Customizer/assets/87810571/57f7c5ed-7140-48d9-bf7a-40322cf4fc58)

修正後は未選択でも枠がなくなります
![image](https://github.com/kaonasi-biwa/Twitter-UI-Customizer/assets/87810571/b54bbe21-b1e5-497a-a419-fd7b0e670bb6)
![image](https://github.com/kaonasi-biwa/Twitter-UI-Customizer/assets/87810571/386fa131-57b6-4d8d-a976-c06d8893bcd3)
