### PR TITLE
設定画面のUIをTwitterと同化させる

### DIFF
--- a/scr/applyCSS.js
+++ b/scr/applyCSS.js
@@ -249,6 +249,7 @@ scrollbar-width:thin;
     padding-right:10px;
     padding-top:10px;
     background-color:var(--TUIC-container-background);
+    font-family: sans-serif;
 }
 .TUICDetails:not([open]){
     padding-bottom:10px;
@@ -366,6 +367,24 @@ textarea#css_textarea,.TUICTextInput {
     border: 1px solid #808080;
     border-radius: 6px;
     margin-bottom: 20px;
+}
+
+/* チェックボタン(Transparent) */
+.TUICButtonColorCheck{
+    width: 1.7em;
+    height: 1.7em;
+    border-radius: 50%;
+    border: 2px solid rgb(127, 127, 127);
+    background-color: #fff;
+    margin-right: 0.2em;
+    margin-left: 0.5em;
+}
+.TUICButtonColorCheck[data-checked="true"] {
+    /* チェックされている */
+	background-position: center;
+	background-size: 90%;
+    background-color: rgba(29,161,242,1);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
 }
 
 

--- a/scr/option.js
+++ b/scr/option.js
@@ -42,12 +42,18 @@ const TUICOptionHTML = {
             "single": false
         },
         ".TUICButtonColorCheck": {
-            "type": "change",
+            "type": "click",
             "function": function (event) {
+                if(!event.target.dataset.checked || event.target.dataset.checked!=="true"){
+                    // 未チェック
+                    event.target.dataset.checked = true;
+                } else
+                    event.target.dataset.checked = false;
+                const isChecked = event.target.dataset.checked === "true";
                 let colorValue = TUICLibrary.color.hex2rgb(document.getElementById(`${event.target.getAttribute("TUICColor")}-${event.target.getAttribute("TUICColorType")}`).value)
                 let colorKind = event.target.getAttribute("TUICColorKind")
                 if ((TUICPref[colorKind][event.target.getAttribute("TUICColor")] ?? "unknown") == "unknown") TUICPref[colorKind][event.target.getAttribute("TUICColor")] = {}
-                TUICPref[colorKind][event.target.getAttribute("TUICColor")][event.target.getAttribute("TUICColorType")] = `rgba(${colorValue[0]},${colorValue[1]},${colorValue[2]},${event.target.checked ? 0 : 1})`
+                TUICPref[colorKind][event.target.getAttribute("TUICColor")][event.target.getAttribute("TUICColorType")] = `rgba(${colorValue[0]},${colorValue[1]},${colorValue[2]},${isChecked ? 0 : 1})`
                 document.getElementById(`${event.target.getAttribute("TUICColor")}-${event.target.getAttribute("TUICColorType")}-default`).classList.remove(TUICLibrary.getClasses.getClass("TUIC_DISPNONE"))
                 localStorage.setItem("TUIC", JSON.stringify(TUICPref))
                 event.currentTarget.parentElement.parentElement.classList.remove(TUICLibrary.getClasses.getClass("TUIC_ISNOTDEFAULT"))
@@ -465,9 +471,10 @@ ${this.checkboxList("clientInfo", "clientInfo-settingTitle", "clientInfo")}
                     </input>
                 </div>
             </div>
-            <input type="checkbox" id="${`${id}-${type}-check`
+            <button type="checkbox" id="${`${id}-${type}-check`
             }" ${TUIC_color[3] == "0" ? "checked" : ""} TUICColor="${id}"
              TUICColorType="${type}" class="TUICButtonColorCheck" TUICColorKind=${colorKind}>
+            </button>
             <label for="${`${id}-${type}-check`
             }" class="r-jwli3a r-1tl8opc r-qvutc0 r-bcqeeo css-901oao TUIC_setting_text" style="font-size:15px;">${TUICLibrary.getI18n("settingUI-colorPicker-transparent")}</label><br>
         </div>


### PR DESCRIPTION
設定画面のUIのフォントが違ったり、チェックボタンのデザインが違ったりしたのを修正しました。
### 変更点
- 設定画面の`.TUICDetails`のフォントをサンセリフ体にしました
- チェックボタン(`.TUICButtonColorCheck`)のデザインを変更しました。
### 写真
#### 変更前
- ![image](https://github.com/kaonasi-biwa/Twitter-UI-Customizer/assets/79000684/f07eefaf-efde-4287-a26c-fd01ec73a268)
- ![image](https://github.com/kaonasi-biwa/Twitter-UI-Customizer/assets/79000684/8603ac88-4d04-412a-a142-a0a7cdf9f6b1)

#### 変更後
- ![image](https://github.com/kaonasi-biwa/Twitter-UI-Customizer/assets/79000684/37a70d7b-7932-4f8d-b2f6-b62b098b57f8)
- ![image](https://github.com/kaonasi-biwa/Twitter-UI-Customizer/assets/79000684/d01215f1-71fe-4912-ad57-cd6ec9ccd0ae)

