### PR TITLE
GitHubから直インストールボタンを追加

### DIFF
--- a/TUIC/popup/popup.html
+++ b/TUIC/popup/popup.html
@@ -73,6 +73,7 @@
       <a href="#" id="link4" class="i18n" i18n-id="popupButton2">セーフモードで設定を変更</a>
       <a href="#" id="link3" class="i18n" i18n-id="popupButton3">アップデート通知の設定</a>
       <a href="#" id="link2" class="i18n" i18n-id="popupButton4">作者(kaonasi_biwa)のTwitter</a>
+      <a href="#" id="link5" class="i18n" i18n-id="popupButton5" hidden>最新版をGitHubからインストール</a>
     </div>
 </body>
 </html>

--- a/TUIC/popup/popup.js
+++ b/TUIC/popup/popup.js
@@ -21,6 +21,9 @@ window.onload = async ()=>{
             .then(res => res.json())
             .then(json => json.tag_name)
             .then(version => {
+                if (!version) {
+                    return;
+                }
                 $link5.href = `https://github.com/kaonasi-biwa/Twitter-UI-Customizer/releases/download/${version}/Twitter_UI_Customizer_Firefox.xpi`
                 $link5.hidden = false;
             });

--- a/TUIC/popup/popup.js
+++ b/TUIC/popup/popup.js
@@ -17,12 +17,12 @@ window.onload = async ()=>{
     
     const $link5 = document.getElementById("link5")
     if (isFirefox) {
-        $link5.hidden = false;
         fetch("https://api.github.com/repos/kaonasi-biwa/Twitter-UI-Customizer/releases/latest", { cache: "no-store" })
             .then(res => res.json())
             .then(json => json.tag_name)
             .then(version => {
                 $link5.href = `https://github.com/kaonasi-biwa/Twitter-UI-Customizer/releases/download/${version}/Twitter_UI_Customizer_Firefox.xpi`
+                $link5.hidden = false;
             });
         } // Firefoxの場合のみ有効
     i18nApply()

--- a/TUIC/popup/popup.js
+++ b/TUIC/popup/popup.js
@@ -1,4 +1,6 @@
-window.onload = ()=>{
+const isFirefox = 'browser' in window;
+
+window.onload = async ()=>{
     chrome.runtime.sendMessage({type:"update",updateType:"iconClick"});
     document.getElementById("link1").onclick = ()=>{
         chrome.tabs.create({"url":"https://twitter.com/settings/display"});
@@ -12,6 +14,17 @@ window.onload = ()=>{
     document.getElementById("link4").onclick = ()=>{
         chrome.tabs.create({"url":"https://twitter.com/tuic/safemode"});
     }
+    
+    const $link5 = document.getElementById("link5")
+    if (isFirefox) {
+        $link5.hidden = false;
+        fetch("https://api.github.com/repos/kaonasi-biwa/Twitter-UI-Customizer/releases/latest", { cache: "no-store" })
+            .then(res => res.json())
+            .then(json => json.tag_name)
+            .then(version => {
+                $link5.href = `https://github.com/kaonasi-biwa/Twitter-UI-Customizer/releases/download/${version}/Twitter_UI_Customizer_Firefox.xpi`
+            });
+        } // Firefoxの場合のみ有効
     i18nApply()
 }
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -53,6 +53,10 @@
         "message": "Author (kaonasi_biwa) on Twitter",
         "description": "ポップアップのボタン"
     },
+    "popupButton5": {
+        "message": "Install latest version from GitHub",
+        "description": "ポップアップのボタン"
+    },
     "optionTitle": {
         "message": "Settings and Operation Method(Twitter UI Customizer)",
         "description": "設定画面のタイトル"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -54,6 +54,10 @@
       "message": "作者(kaonasi_biwa)のTwitter",
       "description": "ポップアップのボタン"
     },
+    "popupButton5": {
+      "message": "最新版をGitHubからインストール",
+      "description": "ポップアップのボタン"
+    },
 
     "optionTitle": {
       "message": "設定及び操作方法(Twitter UI Customizer)",


### PR DESCRIPTION
Firefox系ブラウザの場合に、直接インストールできるボタンを追加しました!
### 変更点
ボタン一つで、最新版をインストールすることができるボタンを追加。Chromium系ブラウザの場合は表示されません。
### 写真
#### Firefox系
![1688892623279](https://github.com/kaonasi-biwa/Twitter-UI-Customizer/assets/79000684/f8efbbdc-20aa-4119-8bf3-5d6a00fedc72)
