### PR TITLE
[Dev] web-ext モジュールを導入する

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,15 @@ https://crowdin.com/project/twiter-ui-customizer
 [System UIcons](https://www.systemuicons.com/)
 
 -   Unlicenseの元で配布されています。
+
+## アドオンのデバッグ方法
+
+**重要** Firefox ブラウザー事前にインストールされている必要があります。また、新しいプロファイルを "about:profile" で "development" という名前で作成する必要があります。プロファイルや環境によるバグを防ぐためにプロファイルは分けられます。
+``
+
+```bash
+npm install
+npm run debug
+```
+
+`npm run debug firefox` も同じ動作を行います。 `npm run debug chrome` は、Chrome でデバッグするために必要な準備を行います。手動でのインストールが必要です。また、web-ext を使用しているためデバッグ中に加えた変更はリロードしなくても反映されます。

--- a/npm-scripts/run.js
+++ b/npm-scripts/run.js
@@ -1,0 +1,51 @@
+/* eslint-disable no-undef */
+const fs = require("fs");
+const { exec } = require("child_process");
+const browser = process.argv[2];
+
+const Functions = {
+    debug: {
+        debugInFirefox() {
+            fs.copyFile("manifest_firefox.json", "manifest.json", (err) => {
+                if (err) {
+                    console.error("Failed to copy and rename the file:", err);
+                    process.exit(1);
+                }
+      
+                exec(`web-ext run --keep-profile-changes --firefox-profile=development --start-url=twitter.com`, (error, stdout, stderr) => {
+                    if (error) {
+                        console.error("Error occurred while running web-ext:", error.message);
+                        console.error("Did you run `npm install`?");
+                        process.exit(1);
+                    }
+                    console.log(stdout);
+                    console.log("If Firefox didn't open, Please check if you have 'Firefox' installed. & Profile 'development' exists.");
+                });
+            });
+        },
+
+        debugInChrome() {
+            fs.copyFile("manifest_chrome.json", "manifest.json", (err) => {
+                if (err) {
+                    console.error("Failed to copy and rename the file:", err);
+                    process.exit(1);
+                }
+                // Chrome doesn"t support web-ext, so we have to run it manually.
+                console.log("Please load Twitetr UI Customizer as an unpacked extension.");
+            });
+        }
+    }
+};
+
+// Run code
+switch (browser) {
+case "firefox":
+    Functions.debug.debugInFirefox();
+    break;
+case "chrome":
+    Functions.debug.debugInChrome();
+    break;
+default:
+    console.log("Not a valid browser or browser name is not provided. Debug in Firefox by default.");
+    Functions.debug.debugInFirefox();
+}

--- a/package.json
+++ b/package.json
@@ -2,10 +2,17 @@
     "devDependencies": {
         "@typescript-eslint/parser": "^6.0.0",
         "eslint-config-prettier": "^8.8.0",
-        "prettier": "^3.0.0"
+        "prettier": "^3.0.0",
+        "web-ext": "^7.6.2"
     },
     "dependencies": {
         "@microsoft/eslint-formatter-sarif": "^2.1.7",
         "eslint": "^8.10.0"
+    },
+
+    "scripts": {
+        "debug" : "node npm-scripts/run.js",
+        "debug firefox": "node npm-scripts/run.js firefox",
+        "debug chrome": "node npm-scripts/run.js chrome"
     }
 }


### PR DESCRIPTION
これによって開発をより迅速に行うことでき、ターミナルだけでアドオンをデバッグできるようになります。

気が向けばビルドプロセスもやろうと思います。

`npm install` と `npm run debug` で試せます。

**重要** Firefox ブラウザー事前にインストールされている必要があります。また、新しいプロファイルを "about:profile" で "development" という名前で作成する必要があります。プロファイルや環境によるバグを防ぐためにプロファイルは分けられます。