### PR TITLE
リリースにCRXを追加

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -24,16 +24,36 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
+            - name: setUpdateUrl
+              run: sed -i 's/${github.repository}/${{ github.repository_owner }}\/${{ github.event.repository.name }}/' manifest_chrome.json
             - name: Archive
               run: |
                   rm manifest_firefox.json
                   mv manifest_chrome.json manifest.json
                   zip -r Twitter_UI_Customizer_Chromium.zip ./ -x "*.git*"
+            - name: CRX
+              uses: cardinalby/webext-buildtools-chrome-crx-action@v2
+              with:
+                      zipFilePath: Twitter_UI_Customizer_Chromium.zip
+                      crxFilePath: Twitter_UI_Customizer_Chromium.crx
+                      privateKey: ${{ secrets.CHROME_EXTENSION_KEY }}
+                      updateXmlPath: crxupdate.xml
+                      updateXmlCodebaseUrl: https://github.com/${{ github.repository }}/releases/latest/download/Twitter_UI_Customizer_Chromium.crx
             - name: Publish
               uses: actions/upload-artifact@v3
               with:
                   name: Twitter_UI_Customizer_Chromium
                   path: Twitter_UI_Customizer_Chromium.zip
+            - name: Publish
+              uses: actions/upload-artifact@v3
+              with:
+                  name: Twitter_UI_Customizer_Chromium_crx
+                  path: Twitter_UI_Customizer_Chromium.crx
+            - name: Publish
+              uses: actions/upload-artifact@v3
+              with:
+                  name: crxupdate
+                  path: crxupdate.xml
 
     make-release:
         runs-on: ubuntu-latest
@@ -56,6 +76,14 @@ jobs:
               uses: actions/download-artifact@v3
               with:
                   name: Twitter_UI_Customizer_Chromium
+            - name: loadFile
+              uses: actions/download-artifact@v3
+              with:
+                  name: Twitter_UI_Customizer_Chromium_crx
+            - name: loadFile
+              uses: actions/download-artifact@v3
+              with:
+                  name: crxupdate
             - name: Upload Release Asset
               id: upload-release-asset
               uses: softprops/action-gh-release@v1
@@ -64,3 +92,5 @@ jobs:
                   files: |
                       Twitter_UI_Customizer_Firefox.xpi
                       Twitter_UI_Customizer_Chromium.zip
+                      Twitter_UI_Customizer_Chromium.crx
+                      crxupdate.xml

--- a/manifest_chrome.json
+++ b/manifest_chrome.json
@@ -4,6 +4,7 @@
     "version": "3.3.1",
     "default_locale": "ja",
     "manifest_version": 3,
+    "update_url": "https://github.com/${github.repository}/releases/latest/download/crxupdate.xml",
     "icons": {
         "16": "icon/newIcon_TUIC_C_Blue.png",
         "48": "icon/newIcon_TUIC_C_Blue.png",


### PR DESCRIPTION
CRXもリリースするようにします。
CRXで拡張機能をインストールすればChrome WebStoreの承認を待たずに更新できる。

ただしChrome/Edge/Braveではレジストリをいじらないと使用できない(ブロックされる)し、
レジストリをいじると"組織によって管理されています"と表示されてしまう。
レジストリをいじる際はhttps://github.com/FilipePS/Traduzir-paginas-web のReadmeを参考に。

あとCRXファイルをChromium系ブラウザでDLする際は"名前をつけて保存"を使用しないと保存されない。

またリポジトリ名が変わって(fork含む)もちゃんと動くように置き換えてるんですけども、不必要なら消してください。

# Setup
CRXをビルドする際には秘密鍵が必要になるんですが、
Chrome WebStoreで使用している秘密鍵と同じものを使用するのは良くないと思うので生成する。

Chromium系ブラウザで開発者モードをオンにした"拡張機能"ページの"拡張機能をパック"を使用すると、
(拡張機能のルートディレクトリにTUICのフォルダを指定してください)
<img width="461" alt="image" src="https://github.com/kaonasi-biwa/Twitter-UI-Customizer/assets/87810571/25789ff4-af0b-4831-a4ad-ed0f6df3652e">
.pemファイルと.crxファイルが生成されるので.pemファイルの中身のテキスト"全て"を、
Actions用のsecretsに"CHROME_EXTENSION_KEY"という名前で登録すればOK。
<img width="850" alt="image" src="https://github.com/kaonasi-biwa/Twitter-UI-Customizer/assets/87810571/56f00cb9-9d6a-4d39-9fab-f40f71518ab0">