### PR TITLE
Chromeではimportを外に出すと動かないため修正

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -2,14 +2,13 @@
  * Twitter UI Customizer
  * << Twitter を思いのままに。 >>
  */
-
-import { TUICObserver } from "./observer.js";
-import { TUICLibrary } from "./library.js";
-import { TUICI18N } from "./i18n.js";
-import { addCssElement } from "./applyCSS.js";
-import { isSafemode, runSafemode } from "./safemode.js";
-
 (async () => {
+    const { TUICObserver } = await import(chrome.runtime.getURL("src/content/observer.js"));
+    const { TUICLibrary } = await import(chrome.runtime.getURL("src/content/library.js"));
+    const { TUICI18N } = await import(chrome.runtime.getURL("src/content/i18n.js"));
+    const { addCssElement } = await import(chrome.runtime.getURL("src/content/applyCSS.js"));
+    const { isSafemode, runSafemode } = await import(chrome.runtime.getURL("src/content/safemode.js"));
+
     await TUICI18N.fetch();
     await TUICLibrary.waitForElement("#react-root");
 


### PR DESCRIPTION
私の環境（Chrome最新）では、importをindex.jsに書くとうまく動かないのでawait importでimportしています。
戻してみたらやはり動かなくなりました。

await importを使用した時でFirefoxやFloorpなどで動かない等なければawait importにしたほうがいいかと思います。