### PR TITLE
セーフモードのUIリデザイン

### DIFF
--- a/src/shared/options/SafeMode.ce.vue
+++ b/src/shared/options/SafeMode.ce.vue
@@ -31,6 +31,7 @@
                 </a>
             </div>
         </nav>
+        <div class="spacer"></div>
         <OptionMain />
     </div>
 </template>
@@ -64,33 +65,36 @@ nav a {
         sans-serif,
         monospace;
     font-weight: bold;
+    text-decoration: none;
 }
 nav {
     position: sticky;
     top: 0px;
     justify-content: space-between;
-    padding-block: 1em;
-    margin-inline: 2em;
-    border-bottom: 1px solid currentColor;
+    border-bottom: 1px solid color-mix(in srgb, var(--TUIC-container-background), var(--twitter-TUIC-color) 20%);
     background-color: var(--TUIC-container-background);
-    border-bottom-left-radius: 1em;
-    border-bottom-right-radius: 1em;
     z-index: 1;
+    padding: 12px 0;
 
     div {
         width: 100%;
     }
     svg {
-        height: 2.5em;
+        height: 1.7em;
         fill: currentColor;
+        width: unset;
         &.icon-tabler {
             fill: none;
             stroke: currentColor;
         }
     }
     span {
-        margin-left: 0.5em;
+        margin-left: 0.3em;
     }
+}
+.spacer {
+    height: 20px;
+    width: 100%;
 }
 @media (max-width: 600px) {
     nav a span {

--- a/src/shared/settings/SettingMain.ce.vue
+++ b/src/shared/settings/SettingMain.ce.vue
@@ -1,7 +1,7 @@
 <template>
     <div id="TUIC_setting" class="css-175oi2r r-1wtj0ep r-ymttw5 r-1f1sjgu r-1e081e0 TUICOriginalContent">
         <div class="css-901oao css-cens5h r-jwli3a r-1tl8opc r-adyw6z r-1vr29t4 r-135wba7 r-bcqeeo r-qvutc0">
-            <hr class="TUIC_setting_divider TUIC_setting_divider_m35" />
+            <hr v-if="!isSafemode" class="TUIC_setting_divider TUIC_setting_divider_m35" />
             <div class="TUIC_setting_toplogo_container">
                 <TUICLOGO_GRAY class="TUIC_setting_toplogo" />
             </div>
@@ -103,6 +103,7 @@ import SettingUncategorized from "./modules/settingUncategorized.vue";
 import SettingImportExport from "./modules/settingImportExport.vue";
 import defaultPrefButton from "./components/defaultPrefButton.vue";
 import IconButton from "./components/IconButton.vue";
+import { isSafemode } from "@content/modules/settings/safemode/isSafemode";
 
 function openReadme() {
     openInNewTab("https://github.com/kaonasi-biwa/Twitter-UI-Customizer/blob/main/README.md");

--- a/src/shared/settings/components/defaultPrefButton.vue
+++ b/src/shared/settings/components/defaultPrefButton.vue
@@ -16,7 +16,7 @@ import IconButton from "@shared/settings/components/IconButton.vue";
 
 const ICON = ICON_RESET;
 const props = defineProps<{
-    classList: string[];
+    classList?: string[];
 }>();
 
 const setDefault = async () => {


### PR DESCRIPTION
# 概要
セーフモードの見た目を、リデザインした設定画面に合うように変更しました。
ダークモード対応しています。
※ ついでにdefaultPrefButtonででていたエラーも修正しました

# 画像
|前|後|
|----|----|
|![image](https://github.com/kaonasi-biwa/Twitter-UI-Customizer/assets/121326808/74e08367-c1da-4edd-a0fd-584863b40b22)|![image](https://github.com/kaonasi-biwa/Twitter-UI-Customizer/assets/121326808/d982c7c0-3cbd-4aa0-b647-209ded58a526)|