### PR TITLE
パフォーマンスを改善したい

### DIFF
--- a/src/content/functions/changeIcon.ts
+++ b/src/content/functions/changeIcon.ts
@@ -125,17 +125,9 @@ export function changeIcon() {
     }
 }
 
-// 起動時のアイコン
-let initIconObserver: MutationObserver | null = null;
-
-export const initIconObserverFunction = () => {
-    if (initIconObserver) initIconObserver.disconnect();
-    else initIconObserver = new MutationObserver(initIconObserverFunction);
-
-    changeIconProcess(document.querySelector(`#placeholder > svg:not([data-tuic-icon-type])`), document.querySelector(`#placeholder`));
-
-    initIconObserver.observe(document.querySelector(`#placeholder > svg`), {
-        attributes: true,
-        attributeFilter: ["class"],
-    });
-};
+/** 起動中に表示されるロゴを変更します。 */
+export function changeLoadingLogo() {
+    const element = document.querySelector<HTMLElement>("#placeholder > svg");
+    if (!element) return;
+    changeIconProcess(element, element.parentElement);
+}

--- a/src/content/functions/changeIcon.ts
+++ b/src/content/functions/changeIcon.ts
@@ -85,7 +85,7 @@ function changeIconProcess(elem: HTMLElement, base: HTMLElement) {
 
 //* setup icon observer
 export function changeIcon() {
-    const notProcessed = `:not([tuic-icon-type])`;
+    const notProcessed = `:not([data-tuic-icon-type])`;
     {
         const elem = document.querySelector<HTMLElement>(`header h1 a > div > svg${notProcessed}`);
         if (elem) {

--- a/src/content/functions/sidebar/extras/dropdown.ts
+++ b/src/content/functions/sidebar/extras/dropdown.ts
@@ -58,7 +58,7 @@ export async function processDropdown() {
 
     // NOTE: すべてのアイテムに対し、隠す処理を行う
     for (const pref of _data.all) {
-        if (!getPref(`sidebarSetting.moreMenuItems.${pref}`)) return;
+        if (!getPref(`sidebarSetting.moreMenuItems.${pref}`)) continue;
 
         const listItemElement = dropdownElement.querySelector(_data.selectors[pref])?.parentElement ?? null;
         if (listItemElement) {

--- a/src/content/functions/sidebar/extras/dropdown.ts
+++ b/src/content/functions/sidebar/extras/dropdown.ts
@@ -5,24 +5,24 @@ import { getPref, getSettingIDs } from "@content/settings";
 const _data = {
     all: getSettingIDs("sidebarSetting.moreMenuItems"),
     selectors: {
-        lists: `[data-testid="Dropdown"] [href$="/lists"]`,
-        bookmarks: `[data-testid="Dropdown"] [href="/i/bookmarks"]`,
-        monetization: `[data-testid="Dropdown"] :is([href="/settings/monetization"],[href="/i/monetization"])`,
-        separator: `[data-testid="Dropdown"] [role="separator"]`,
-        creatorStudio: `[data-testid="Dropdown"] :is([aria-controls$="_0_content"], [href="/i/jf/creators/studio"])`,
-        professionalTool: `[data-testid="Dropdown"] [aria-controls$="_1_content"]`,
-        settingsAndSupport: `[data-testid="Dropdown"] [aria-controls$="_2_content"][data-testid="settingsAndSupport"]`,
-        communities: `[data-testid="Dropdown"] [href$="/communities"]`,
-        communitynotes: `[data-testid="Dropdown"] [href="/i/communitynotes"]`,
-        settings: `[data-testid="Dropdown"] [href="/settings"]`,
-        pro: `[data-testid="Dropdown"] [href="https://tweetdeck.twitter.com"]`,
-        ads: `[data-testid="Dropdown"] :is([href*="ads.twitter.com"],[href*="ads.x.com"])`,
-        premium: `[data-testid="Dropdown"] :is([href="/i/verified-choose"],[href="/i/premium_sign_up"])`,
-        jobs: `[data-testid="Dropdown"] [href="/jobs"]`,
-        spaces: `[data-testid="Dropdown"] [href="/i/spaces/start"]`,
-        followerRequests: `[data-testid="Dropdown"] [href="/follower_requests"]`,
-        verifiedOrgsSignup: `[data-testid="Dropdown"] [href="/i/verified-orgs-signup"]`,
-        chat: `[data-testid="Dropdown"] [href="/i/chat"]`,
+        lists: `[href$="/lists"]`,
+        bookmarks: `[href="/i/bookmarks"]`,
+        monetization: `:is([href="/settings/monetization"],[href="/i/monetization"])`,
+        separator: `[role="separator"]`,
+        creatorStudio: `:is([aria-controls$="_0_content"], [href="/i/jf/creators/studio"])`,
+        professionalTool: `[aria-controls$="_1_content"]`,
+        settingsAndSupport: `[aria-controls$="_2_content"][data-testid="settingsAndSupport"]`,
+        communities: `[href$="/communities"]`,
+        communitynotes: `[href="/i/communitynotes"]`,
+        settings: `[href="/settings"]`,
+        pro: `[href="https://tweetdeck.twitter.com"]`,
+        ads: `:is([href*="ads.twitter.com"],[href*="ads.x.com"])`,
+        premium: `:is([href="/i/verified-choose"],[href="/i/premium_sign_up"])`,
+        jobs: `[href="/jobs"]`,
+        spaces: `[href="/i/spaces/start"]`,
+        followerRequests: `[href="/follower_requests"]`,
+        verifiedOrgsSignup: `[href="/i/verified-orgs-signup"]`,
+        chat: `[href="/i/chat"]`,
     },
     type: {
         bookmarks: "menuitem",
@@ -46,21 +46,28 @@ const _data = {
 
 /** サイドバーのドロップダウン中から、不要な要素を隠します。 */
 export async function processDropdown() {
-    await waitForElement(`[data-testid="Dropdown"]`);
-    let menuTopPx = parseFloat(document.querySelector<HTMLDivElement>(`[role="menu"]`).style.top);
-    const upPx = {
+    const dropdownElement = (await waitForElement<HTMLDivElement>(`[role="menu"]:has([data-testid="Dropdown"])`))[0];
+
+    // NOTE: ドロップダウンメニューの位置を下げるため、現在の位置を取得しておく
+    let dropdownY = parseFloat(dropdownElement.style.top);
+    const listItemHeights = {
         menu: fontSizeClass(46, 49, 52, 58, 62),
         menuitem: fontSizeClass(50, 53, 56, 62, 67),
         separator: 5,
     };
+
+    // NOTE: すべてのアイテムに対し、隠す処理を行う
     for (const pref of _data.all) {
-        if (getPref(`sidebarSetting.moreMenuItems.${pref}`)) {
-            const elem = document.querySelector(_data.selectors[pref]);
-            if (elem) {
-                hideElement(elem.parentElement);
-                menuTopPx += upPx[_data.type[pref]];
-            }
+        if (!getPref(`sidebarSetting.moreMenuItems.${pref}`)) return;
+
+        const listItemElement = dropdownElement.querySelector(_data.selectors[pref])?.parentElement ?? null;
+        if (listItemElement) {
+            hideElement(listItemElement);
+
+            // NOTE: ドロップダウンメニューの位置を下げる
+            dropdownY += listItemHeights[_data.type[pref]];
         }
     }
-    document.querySelector<HTMLDivElement>(`[role="menu"]`).style.top = menuTopPx + "px";
+
+    dropdownElement.style.top = dropdownY + "px";
 }

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -8,7 +8,7 @@ import { loadI18n, translate } from "@content/i18n";
 import { injectSettingsStyle, injectSystemIconStyle, injectSettingsIconStyle, injectSystemStyle, cleanModifiedElements, injectCustomStyle } from "@content/applyCSS";
 import { isSafemode, runSafemode } from "@content/settings/ui/safemode";
 import { startTluiObserver } from "@shared/tlui/observer";
-import { initIconObserverFunction } from "@content/functions/changeIcon";
+import { changeLoadingLogo } from "@content/functions/changeIcon";
 import { setTitleObserver } from "@content/functions/replaceTitleX";
 import { runSettingComponentObserver } from "@content/settings/ui";
 import { placePrintPrefButton } from "./printPref";
@@ -82,9 +82,7 @@ import { waitForElement } from "@content/utils/element";
         injectSettingsIconStyle();
 
         // 起動時のTwitterアイコンを変更
-        if (document.querySelector(`#placeholder > svg`)) {
-            initIconObserverFunction();
-        }
+        changeLoadingLogo();
 
         // タイトル変更のためのObserver
         waitForElement("title").then(setTitleObserver);


### PR DESCRIPTION
無駄な MutationObserver を減らすのと、CSS を控える方向で動きたいけど難しそう

今のところ DOM 変更に伴う CSS 再計算が重いんじゃないかと考えてる
特に DevTools の Performance タブでは `[出典不明]` が多くて、その中で「確定」「Microtasks の実行」「スクリプトの評価」「イベント: visibilitychange」などは目につく

何しろ DOM 要素が多くてかなり厳しい